### PR TITLE
Add exclude_ids parameter for infinite recommendation scrolling

### DIFF
--- a/api/inference/recommender.py
+++ b/api/inference/recommender.py
@@ -12,6 +12,7 @@ def get_recommendations(
     anime_ids: list[int],
     anime_df: pd.DataFrame,
     top_n: int = DEFAULT_TOP_N,
+    exclude_ids: list[int] | None = None,
     device: str = 'cpu',
 ) -> pd.DataFrame:
     rbm.eval()
@@ -28,6 +29,13 @@ def get_recommendations(
 
     liked_indices = np.where(input_vector.cpu().numpy().flatten() == 1)[0]
     scores[liked_indices] = -1e6
+
+    # Exclude previously shown anime
+    if exclude_ids:
+        anime_id_to_idx = {aid: idx for idx, aid in enumerate(anime_ids)}
+        for exclude_id in exclude_ids:
+            if exclude_id in anime_id_to_idx:
+                scores[anime_id_to_idx[exclude_id]] = -1e6
 
     top_indices = scores.argsort()[::-1][:top_n]
     top_anime_ids = [anime_ids[i] for i in top_indices]

--- a/api/main.py
+++ b/api/main.py
@@ -58,6 +58,7 @@ class RecommendRequest(BaseModel):
     """Request body for getting recommendations."""
     liked_anime: list[str]
     top_n: int = DEFAULT_TOP_N
+    exclude_ids: list[int] = []
 
 
 class AnimeResult(BaseModel):
@@ -285,9 +286,10 @@ async def recommend(request: Request, body: RecommendRequest):
 
     try:
         top_n = min(body.top_n, 50)
-        logger.info(f"Generating {top_n} recommendations for {len(matched_ids)} matched anime")
+        exclude_ids = body.exclude_ids[:200]
+        logger.info(f"Generating {top_n} recommendations for {len(matched_ids)} matched anime (excluding {len(exclude_ids)} IDs)")
         input_vec = torch.FloatTensor([[1 if a in matched_ids else 0 for a in anime_ids]]).to(device)
-        recs = get_recommendations(input_vec.squeeze(0), rbm, anime_ids, anime_df, top_n=top_n, device=device)
+        recs = get_recommendations(input_vec.squeeze(0), rbm, anime_ids, anime_df, top_n=top_n, exclude_ids=exclude_ids, device=device)
         logger.info(f"Got {len(recs)} recommendations")
         
         recommendations = []

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,9 @@ services:
       - USER_REVIEW_CSV_URI=${USER_REVIEW_CSV_URI}
       - ALLOWED_ORIGINS=${ALLOWED_ORIGINS}
       - DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
+      - JWT_SECRET_KEY=${JWT_SECRET_KEY}
+      - JWT_ALGORITHM=${JWT_ALGORITHM}
+      - JWT_ACCESS_TOKEN_EXPIRE_MINUTES=${JWT_ACCESS_TOKEN_EXPIRE_MINUTES}
     depends_on:
       db:
         condition: service_healthy

--- a/rbm/constants.py
+++ b/rbm/constants.py
@@ -1,8 +1,6 @@
 import os
 from typing import Dict, List
 
-HTTP_BAD_REQUEST = 400
-
 RATING_THRESHOLD = 7
 
 CLAMP_MIN = 0.0


### PR DESCRIPTION
- Add exclude_ids parameter to /recommend API endpoint to exclude previously shown anime from results
- Update frontend to track shown recommendation IDs and fetch more when cards are removed
- Add JWT environment variables to docker-compose.yml
- Remove unused HTTP_BAD_REQUEST constant from rbm/constants.py